### PR TITLE
Check lsp clients for capabilitiy in lsp_tags

### DIFF
--- a/lua/qwahl.lua
+++ b/lua/qwahl.lua
@@ -132,7 +132,14 @@ function M.lsp_tags(opts)
     end
     return false
   end
-  assert(next(vim.lsp.buf_get_clients()), "Must have a client running to use lsp_tags")
+  local has_eligible_client = false
+  for _, client in pairs(vim.lsp.buf_get_clients()) do
+    if client.server_capabilities.documentSymbolProvider then
+      has_eligible_client = true
+      break
+    end
+  end
+  assert(has_eligible_client, "Must have a client running to use lsp_tags")
   vim.lsp.buf_request(0, 'textDocument/documentSymbol', params, function(err, result)
     assert(not err, vim.inspect(err))
     if not result then


### PR DESCRIPTION
Otherwise the `try(lsp_tags, buf_tags)` pattern doesn't work if there
there are clients but all lack the documentSymbol capability
