### PR TITLE
Use `:cc` to switch to quickfix entry

### DIFF
--- a/doc/qwahl.txt
+++ b/doc/qwahl.txt
@@ -1,4 +1,4 @@
-================================================================================
+==============================================================================
 Collection of pickers utilizing vim.ui.select                            *qwahl*
 
 M.format_bufname({bufnr})                                 *qwahl.format_bufname*
@@ -10,7 +10,7 @@ M.format_bufname({bufnr})                                 *qwahl.format_bufname*
         {bufnr}  (number)
 
     Returns: ~
-        {string}
+        (string)
 
 
 M.try()                                                              *qwahl.try*

--- a/lua/qwahl.lua
+++ b/lua/qwahl.lua
@@ -292,17 +292,12 @@ function M.quickfix()
       return M.format_bufname(item.bufnr) .. ': ' .. item.text
     end
   }
-  ui.select(items, opts, function(item)
+  ui.select(items, opts, function(item, idx)
     if not item then
       return
     end
-    vim.fn.bufload(item.bufnr)
-    api.nvim_win_set_buf(win, item.bufnr)
-    local ok = pcall(api.nvim_win_set_cursor, win, {item.lnum, item.col - 1})
-    if not ok then
-      api.nvim_win_set_cursor(win, {item.lnum, 0})
-    end
     api.nvim_win_call(win, function()
+      vim.cmd('cc ' .. tostring(idx))
       vim.cmd('normal! zvzz')
     end)
   end)


### PR DESCRIPTION
Has the advantage that it also changes the selected item in the quickfix
list which allows users to move further with :cnext
