### PR TITLE
Fix don't show not listed buffers

### DIFF
--- a/lua/qwahl.lua
+++ b/lua/qwahl.lua
@@ -66,7 +66,7 @@ end
 function M.buffers()
   local bufs = vim.tbl_filter(
     function(b)
-      return api.nvim_buf_is_loaded(b) and api.nvim_buf_get_option(b, 'buftype') ~= 'quickfix'
+      return vim.fn.buflisted(b) == 1 and api.nvim_buf_get_option(b, 'buftype') ~= 'quickfix'
     end,
     api.nvim_list_bufs()
   )


### PR DESCRIPTION
With #9 now we can open helpfiles. A problem I've encountered is that since we weren't checking if the buffer had the 'buflisted' option, when I searched throw my buffer, fullpaths to the help files were showed to me.

<img width="638" alt="Screenshot 2023-10-06 at 22 18 03" src="https://github.com/mfussenegger/nvim-qwahl/assets/96259932/5d8925c6-4e5a-4535-a097-e5979f7913a1">