### PR TITLE
Add timeout option for lsp_tags

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,10 @@ jobs:
         neovim_version: ['nightly']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: date +%F > todays-date
       - name: Restore cache for today's nightly.
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: _neovim
           key: ${{ runner.os }}-x64-${{ hashFiles('todays-date') }}


### PR DESCRIPTION
This can be useful to have `buf_tags` as fallback for slow lsp
operations - which can be the case if the language server is still
starting up or scanning the workspace

For example:

    local q = require('qwahl')
    q.try(
      function()
        q.lsp_tags({ timeout = 1000 })
      end,
      q.buf_tags
    )
